### PR TITLE
Fix linking math.h on gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ defullbright.exe: defullbright.c
 	i686-w64-mingw32-gcc -o defullbright.exe defullbright.c
 
 defullbright: defullbright.c
-	gcc -Wall -o defullbright defullbright.c
+	gcc -Wall -o defullbright defullbright.c -lm
 
 clean:
 	rm -f defullbright defullbright.exe


### PR DESCRIPTION
Just adds a flag to link math.h properly for gcc builds.